### PR TITLE
Update to the newer Play Integrity version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation 'androidx.browser:browser:1.4.0'
 
-    implementation("com.google.android.play:integrity:1.0.1")
+    implementation("com.google.android.play:integrity:1.4.0")
     implementation("com.google.android.gms:play-services-safetynet:18.0.1")
     implementation('com.google.http-client:google-http-client-android:1.42.0') {
         // otherwise conflicts, has to be excluded


### PR DESCRIPTION
Add newer version of PI as now there are more options available regarding the verification of the APP. Check: https://developer.android.com/google/play/integrity/remediation

I don't think the banner is necessary but I believe the version can make a difference: https://developer.android.com/google/play/integrity/remediation#request_an_integrity_dialog